### PR TITLE
Avoid 100% CPU by polling on SocketReadMessage

### DIFF
--- a/WolframLanguageServer/Server.wl
+++ b/WolframLanguageServer/Server.wl
@@ -404,7 +404,7 @@ ReadMessagesImpl[client_SocketObject, {{remainingLength_Integer, remainingByte:(
         If[Length[remainingByte] >= remainingLength,
             {{0, Drop[remainingByte, remainingLength]}, {msgs, ImportByteArray[Take[remainingByte, remainingLength], "RawJSON"]}},
             (* Read more *)
-            {{remainingLength, ByteArray[remainingByte ~Join~ SocketReadMessage[client]]}, {msgs}}
+            {{remainingLength, ByteArray[remainingByte ~Join~ BlockingSocketReadMessage[client]]}, {msgs}}
         ],
         (* New header *)
         Replace[SequencePosition[Normal @ remainingByte, RPCPatterns["SequenceSplitPattern"], 1], {
@@ -412,12 +412,13 @@ ReadMessagesImpl[client_SocketObject, {{remainingLength_Integer, remainingByte:(
 	            {{getContentLength[Take[remainingByte, end1 - 1]], Drop[remainingByte, end2]}, {msgs}}
 	        ),
 	        {} :> ( (* Read more *)
-	            {{0, ByteArray[remainingByte ~Join~ SocketReadMessage[client]]}, {msgs}}
+	            {{0, ByteArray[remainingByte ~Join~ BlockingSocketReadMessage[client]]}, {msgs}}
 		    )
 	    }]
 	]
 ]]
 
+BlockingSocketReadMessage[client_] := (While[!SocketReadyQ[client], Pause[1/2]]; SocketReadMessage[client])
 
 (* ::Subsubsection:: *)
 (*NamedPipe*)


### PR DESCRIPTION
SocketReadMessage does not block, it hangs until it is able to read a message from the socket. This led to 100% CPU when I tried executing the server.

I am not sure if what I modified in the code is a solution or a quick fix, because maybe there are underlying reasons to the problem (like "the socket should have been ready at the time of the read") which went unnoticed by what I propose.

